### PR TITLE
Feature completion

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -7,10 +7,24 @@ class App < ActiveRecord::Base
 
   validate :auth_secret_must_be_sufficiently_strong
 
+  def define_build(params = {})
+    ::App::Build.new(params.merge(app_id: id))
+  end
+
   private
 
   def auth_secret_must_be_sufficiently_strong
     return if auth_secret && auth_secret.size >= 43
     errors.add(:auth_secret, "must be at least 32-bytes, Base64 encoded")
+  end
+
+  class Build
+    attr_reader :app_id, :version, :built_at
+
+    def initialize(app_id:, version:, built_at:)
+      @app_id = app_id
+      @version = AppVersion.new(version)
+      @built_at = built_at
+    end
   end
 end

--- a/app/models/app_version.rb
+++ b/app/models/app_version.rb
@@ -16,7 +16,7 @@ class AppVersion
   end
 
   def initialize(version_number)
-    raise "version_number must be an string, integer, or AppVersion" unless [String, Integer, AppVersion].any? do |t|
+    raise "version_number must be a string, integer, or AppVersion" unless [String, Integer, AppVersion].any? do |t|
       version_number.is_a?(t)
     end
     version_number = version_number.to_s

--- a/app/models/app_version.rb
+++ b/app/models/app_version.rb
@@ -16,6 +16,9 @@ class AppVersion
   end
 
   def initialize(version_number)
+    raise "version_number must be an string, integer, or AppVersion" unless [String, Integer, AppVersion].any? do |t|
+      version_number.is_a?(t)
+    end
     version_number = version_number.to_s
     raise "version_number must be present" if version_number.blank?
     raise "version_number is too long" if version_number.length > MAX_LENGTH

--- a/app/models/app_version.rb
+++ b/app/models/app_version.rb
@@ -8,7 +8,11 @@ class AppVersion
   attr_reader :version_number
 
   def self.from_a(ary)
-    ary && new(ary.map(&:to_s).join("."))
+    new(ary.map(&:to_s).join("."))
+  end
+
+  def self.from_pg_array(value)
+    from_a(value.scan(/\d+/))
   end
 
   def initialize(version_number)

--- a/app/models/app_version.rb
+++ b/app/models/app_version.rb
@@ -1,0 +1,37 @@
+class AppVersion
+  include Comparable
+
+  DECIMAL_INTEGER = /(?:0|[1-9]\d*)/
+  VERSION_REGEX = /\A(?:#{DECIMAL_INTEGER}\.){0,2}#{DECIMAL_INTEGER}\z/ # iOS rules currently, but can be relaxed from here
+  MAX_LENGTH = 18 # iOS rules
+
+  attr_reader :version_number
+
+  def self.from_a(ary)
+    ary && new(ary.map(&:to_s).join("."))
+  end
+
+  def initialize(version_number)
+    version_number = version_number.to_s
+    raise "version_number must be present" if version_number.blank?
+    raise "version_number is too long" if version_number.length > MAX_LENGTH
+    raise "version_number does not conform to format" unless version_number.match(VERSION_REGEX)
+    @version_number = version_number
+  end
+
+  def to_a
+    @to_a ||= version_number.split('.').map { |n| Integer(n) }
+  end
+
+  def to_s
+    version_number
+  end
+
+  def inspect
+    "#<AppVersion: #{self}>"
+  end
+
+  def <=>(other)
+    to_a <=> other.to_a
+  end
+end

--- a/app/models/app_version.rb
+++ b/app/models/app_version.rb
@@ -27,6 +27,10 @@ class AppVersion
     version_number
   end
 
+  def to_pg_array
+    "{#{to_a.join(',')}}"
+  end
+
   def inspect
     "#<AppVersion: #{self}>"
   end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -40,7 +40,7 @@ class Assignment < ActiveRecord::Base
     def for_app_build(app_build)
       where("splits.finished_at is null or splits.finished_at > ?", app_build.built_at)
         .where(<<~SQL, app_build.app_id, app_build.version.to_pg_array)
-          splits.name not like '%_enabled'
+          splits.feature_gate = false
           or exists (
             select 1 from feature_completions fc
             where fc.app_id = ?

--- a/app/models/feature_completion.rb
+++ b/app/models/feature_completion.rb
@@ -1,0 +1,8 @@
+class FeatureCompletion < ActiveRecord::Base
+  belongs_to :split
+  belongs_to :app
+
+  validates :split_id, uniqueness: { scope: :app_id }
+
+  attribute :version, :app_version
+end

--- a/app/models/feature_completion.rb
+++ b/app/models/feature_completion.rb
@@ -2,7 +2,8 @@ class FeatureCompletion < ActiveRecord::Base
   belongs_to :split
   belongs_to :app
 
-  validates :split_id, uniqueness: { scope: :app_id }
+  validates :split, uniqueness: { scope: :app }
+  validates :split, :app, :version, presence: true
 
   attribute :version, :app_version
 end

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -19,7 +19,9 @@ class Split < ActiveRecord::Base
 
   before_validation :cast_registry
 
-  scope :active, -> { where(finished_at: nil) }
+  scope :active, ->(as_of: nil) do
+    as_of ? where('splits.finished_at is null or splits.finished_at > ?', as_of) : where(finished_at: nil)
+  end
 
   enum platform: %i(mobile desktop)
 

--- a/app/types/app_version_type.rb
+++ b/app/types/app_version_type.rb
@@ -6,10 +6,10 @@ class AppVersionType < ActiveRecord::Type::Value
   end
 
   def serialize(value)
-    value.to_pg_array
+    value.to_pg_array if value
   end
 
   def deserialize(value)
-    AppVersion.from_a(value.scan(/\d+/)) if value
+    AppVerrsion.from_pg_array(value) if value
   end
 end

--- a/app/types/app_version_type.rb
+++ b/app/types/app_version_type.rb
@@ -1,0 +1,15 @@
+class AppVersionType < ActiveRecord::Type::Value
+  def cast(value)
+    AppVersion.new(value)
+  rescue
+    nil
+  end
+
+  def serialize(value)
+    "{#{value.to_a.join(',')}}"
+  end
+
+  def deserialize(value)
+    AppVersion.from_a(value.scan(/\d+/))
+  end
+end

--- a/app/types/app_version_type.rb
+++ b/app/types/app_version_type.rb
@@ -1,15 +1,15 @@
 class AppVersionType < ActiveRecord::Type::Value
   def cast(value)
-    AppVersion.new(value)
-  rescue
+    value.to_s.present? ? AppVersion.new(value) : nil
+  rescue StandardError
     nil
   end
 
   def serialize(value)
-    "{#{value.to_a.join(',')}}"
+    value.to_pg_array
   end
 
   def deserialize(value)
-    AppVersion.from_a(value.scan(/\d+/))
+    AppVersion.from_a(value.scan(/\d+/)) if value
   end
 end

--- a/app/types/app_version_type.rb
+++ b/app/types/app_version_type.rb
@@ -1,6 +1,6 @@
 class AppVersionType < ActiveRecord::Type::Value
   def cast(value)
-    value.to_s.present? ? AppVersion.new(value) : nil
+    AppVersion.new(value) unless value.nil?
   rescue StandardError
     nil
   end

--- a/app/types/app_version_type.rb
+++ b/app/types/app_version_type.rb
@@ -10,6 +10,6 @@ class AppVersionType < ActiveRecord::Type::Value
   end
 
   def deserialize(value)
-    AppVerrsion.from_pg_array(value) if value
+    AppVersion.from_pg_array(value) if value
   end
 end

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Type.register(:app_version, AppVersionType)

--- a/db/migrate/20190401094449_create_feature_completions.rb
+++ b/db/migrate/20190401094449_create_feature_completions.rb
@@ -1,0 +1,12 @@
+class CreateFeatureCompletions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :feature_completions, id: :uuid, default: -> { "uuid_generate_v4()" } do |t|
+      t.references :split, type: :uuid, null: false, foreign_key: true
+      t.references :app, type: :uuid, null: false, foreign_key: true
+      t.integer :version, array: true, null: false
+      t.timestamps
+    end
+
+    add_index :feature_completions, [:split_id, :app_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190317143114) do
+ActiveRecord::Schema.define(version: 20190401094449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,17 @@ ActiveRecord::Schema.define(version: 20190317143114) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "feature_completions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid "split_id", null: false
+    t.uuid "app_id", null: false
+    t.integer "version", null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["app_id"], name: "index_feature_completions_on_app_id"
+    t.index ["split_id", "app_id"], name: "index_feature_completions_on_split_id_and_app_id", unique: true
+    t.index ["split_id"], name: "index_feature_completions_on_split_id"
   end
 
   create_table "identifier_types", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -185,6 +196,8 @@ ActiveRecord::Schema.define(version: 20190317143114) do
   add_foreign_key "assignments", "visitors"
   add_foreign_key "bulk_assignments", "admins"
   add_foreign_key "bulk_assignments", "splits"
+  add_foreign_key "feature_completions", "apps"
+  add_foreign_key "feature_completions", "splits"
   add_foreign_key "identifier_types", "apps", column: "owner_app_id"
   add_foreign_key "identifiers", "identifier_types"
   add_foreign_key "identifiers", "visitors"

--- a/spec/factories/feature_completions.rb
+++ b/spec/factories/feature_completions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :feature_completion do
+    split
+    app
+    version { "1.0" }
+  end
+end

--- a/spec/models/app_version_spec.rb
+++ b/spec/models/app_version_spec.rb
@@ -59,4 +59,10 @@ RSpec.describe AppVersion do
       expect(described_class.from_a([1, 0, 20])).to eq described_class.new("1.0.20")
     end
   end
+
+  describe ".from_pg_array" do
+    it "ingests a PG array literal" do
+      expect(described_class.from_pg_array('{1,0,20}')).to eq described_class.new("1.0.20")
+    end
+  end
 end

--- a/spec/models/app_version_spec.rb
+++ b/spec/models/app_version_spec.rb
@@ -44,7 +44,13 @@ RSpec.describe AppVersion do
 
   describe "#to_a" do
     it "returns an array of integer parts" do
-      expect(described_class.new("1.0.20")).to eq [1, 0, 20]
+      expect(described_class.new("1.0.20").to_a).to eq [1, 0, 20]
+    end
+  end
+
+  describe "#to_pg_array" do
+    it "returns a postgresql array literal representation of the version" do
+      expect(described_class.new("1.0.20").to_pg_array).to eq '{1,0,20}'
     end
   end
 

--- a/spec/models/app_version_spec.rb
+++ b/spec/models/app_version_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe AppVersion do
+  it "doesn't allow an empty version number" do
+    expect { described_class.new("") }.to raise_error(/must be present/)
+  end
+
+  it "can parse an iOS-style version number" do
+    expect { described_class.new("1.0.0") }.not_to raise_error
+  end
+
+  it "can parse an Android-style versionCode as a string or integer" do
+    expect { described_class.new("100") }.not_to raise_error
+    expect { described_class.new(100) }.not_to raise_error
+  end
+
+  it "doesn't allow 0-prefixes (which would parse as octal)" do
+    expect { described_class.new("07") }.to raise_error(/format/)
+  end
+
+  it "can collate version numbers numerically by position" do
+    expect(described_class.new("0.20")).to be < described_class.new("0.100")
+    expect(described_class.new("0.100")).to be > described_class.new("0.20")
+
+    expect(described_class.new("1.2")).to be < described_class.new("2.1")
+    expect(described_class.new("2.1")).to be > described_class.new("1.2")
+
+    expect(described_class.new("1.0.0")).to eq described_class.new("1.0.0")
+
+    expect(described_class.new("1.0.0")).not_to eq described_class.new("1.0")
+  end
+
+  it "can instantiate from another AppVersion" do
+    expect(described_class.new(described_class.new("1.0.0"))).to eq described_class.new("1.0.0")
+  end
+
+  describe "#to_s" do
+    it "returns the unmolested input value as a string" do
+      expect(described_class.new("100.0").to_s).to eq "100.0"
+
+      expect(described_class.new(100).to_s).to eq "100"
+    end
+  end
+
+  describe "#to_a" do
+    it "returns an array of integer parts" do
+      expect(described_class.new("1.0.20")).to eq [1, 0, 20]
+    end
+  end
+
+  describe ".from_a" do
+    it "ingests an array representation" do
+      expect(described_class.from_a([1, 0, 20])).to eq described_class.new("1.0.20")
+    end
+  end
+end

--- a/spec/models/app_version_spec.rb
+++ b/spec/models/app_version_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe AppVersion do
     expect { described_class.new("07") }.to raise_error(/format/)
   end
 
+  it "doesn't allow floats because of precision loss" do
+    v = 1.20
+    expect(v.to_s).to eq "1.2"
+    expect { described_class.new(v) }.to raise_error(/integer/)
+  end
+
+  it "doesn't allow BigDecimals because of precision loss" do
+    v = BigDecimal("1.20")
+    expect(v.to_s).to eq "1.2"
+    expect { described_class.new(v) }.to raise_error(/integer/)
+  end
+
   it "can collate version numbers numerically by position" do
     expect(described_class.new("0.20")).to be < described_class.new("0.100")
     expect(described_class.new("0.100")).to be > described_class.new("0.20")

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Assignment, type: :model do
     end
 
     context "with app_build provided" do
-      let(:feature_gate) { FactoryBot.create(:split, name: "bla_enabled") }
+      let(:feature_gate) { FactoryBot.create(:split, name: "bla_enabled", feature_gate: true) }
       let(:random_split) { FactoryBot.create(:split, name: "random") }
       let(:app) { FactoryBot.create(:app) }
       let(:new_app_build) { app.define_build(version: "5.0.1", built_at: Time.zone.now) }

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -166,4 +166,37 @@ RSpec.describe Split, type: :model do
       expect(decision.send(:split)).to eq subject
     end
   end
+
+  describe ".active" do
+    it "returns unfinished splits without arguments" do
+      split = FactoryBot.create(:split)
+
+      expect(described_class.active).to include(split)
+    end
+
+    it "returns unfinished splits with as_of: provided" do
+      split = FactoryBot.create(:split)
+
+      expect(described_class.active(as_of: Time.zone.now)).to include(split)
+    end
+
+    it "returns splits finished after as_of:" do
+      split = FactoryBot.create(:split, finished_at: Time.zone.now)
+
+      expect(described_class.active(as_of: 1.minute.ago)).to include(split)
+    end
+
+    it "doesn't return splits finished at simultaneously with as_of:" do
+      t = Time.zone.now
+      split = FactoryBot.create(:split, finished_at: t)
+
+      expect(described_class.active(as_of: t)).not_to include(split)
+    end
+
+    it "doesn't return splits finished before as_of:" do
+      split = FactoryBot.create(:split, finished_at: 1.day.ago)
+
+      expect(described_class.active(as_of: Time.zone.now)).not_to include(split)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

This adds a FeatureCompletion model and wires it into split visibility.

Notably this doesn't actually affect production behavior, and it's missing a piece before it would be safe. We also need to wire up modifications to the weighting registry for display to the same app (basically overriding displayed weightings to 100% `false` for feature gates on app versions that aren't in the feature-complete set).

I'm daisy-chaining this off of my prior PR for now.

Will mark up below.

/domain @Betterment/test_track_core 
/platform @samandmoore @smudge