### PR TITLE
Split creations to upserts

### DIFF
--- a/app/controllers/admin/split_configs_controller.rb
+++ b/app/controllers/admin/split_configs_controller.rb
@@ -19,6 +19,6 @@ class Admin::SplitConfigsController < AuthenticatedAdminController
   private
 
   def update_params
-    params.require(:split_creation).permit(weighting_registry: @split.registry.keys)
+    params.require(:split_upsert).permit(weighting_registry: @split.registry.keys)
   end
 end

--- a/app/controllers/api/v1/split_configs_controller.rb
+++ b/app/controllers/api/v1/split_configs_controller.rb
@@ -1,10 +1,10 @@
 class Api::V1::SplitConfigsController < AuthenticatedApiController
   def create
-    split_creation = SplitCreation.new(create_params.merge(app: current_app))
-    if split_creation.save
+    split_upsert = SplitUpsert.new(create_params.merge(app: current_app))
+    if split_upsert.save
       head :no_content
     else
-      render_errors split_creation
+      render_errors split_upsert
     end
   end
 

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -55,7 +55,7 @@ class Split < ActiveRecord::Base
   end
 
   def build_config(params = {})
-    SplitCreation.new({ weighting_registry: registry, name: name, app: owner_app }.merge(params))
+    SplitUpsert.new({ weighting_registry: registry }.merge(params).merge(name: name, app: owner_app))
   end
 
   def reconfigure!(params = {})

--- a/app/models/split_upsert.rb
+++ b/app/models/split_upsert.rb
@@ -1,4 +1,4 @@
-class SplitCreation
+class SplitUpsert
   include ActiveModel::Model
 
   attr_accessor :app, :name, :decided_at

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -127,12 +127,21 @@ RSpec.describe Split, type: :model do
       expect(config.name).to eq "my_split"
     end
 
-    it "allows params to be overridden" do
-      subject.name = "my_split"
-      config = subject.build_config(name: "a different name", weighting_registry: { foobar: 100 })
+    it "allows weighting registry to be overridden" do
+      config = subject.build_config(weighting_registry: { foobar: 100 })
       expect(config.weighting_registry).to eq("foobar" => 100)
+    end
+
+    it "doesn't allow split name to be overridden" do
+      subject.name = "my_split"
+      config = subject.build_config(name: "a different name")
+      expect(config.name).to eq "my_split"
+    end
+
+    it "doesn't allow app to be overridden" do
+      subject.name = "my_split"
+      config = subject.build_config(app: FactoryBot.build_stubbed(:app))
       expect(config.app).to eq subject.owner_app
-      expect(config.name).to eq "a different name"
     end
   end
 

--- a/spec/models/split_upsert_spec.rb
+++ b/spec/models/split_upsert_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
-RSpec.describe SplitCreation do
+RSpec.describe SplitUpsert do
   let(:default_app) { FactoryBot.create :app, name: "default_app", auth_secret: "6Sd6T7T6Q8hKcoo0t8CTzV0IdN1EEHqXB2Ig4raZsOU" }
 
   let(:bad_weather) { { rain: 20, snow: 20, hurricane: 60 }.stringify_keys }
-  let(:bad_weather_create) { SplitCreation.new(app: default_app, name: "weather", weighting_registry: bad_weather) }
+  let(:bad_weather_create) { SplitUpsert.new(app: default_app, name: "weather", weighting_registry: bad_weather) }
 
   let(:good_weather) { { clear_skies: 100 }.stringify_keys }
-  let(:good_weather_create) { SplitCreation.new(app: default_app, name: "weather", weighting_registry: good_weather) }
+  let(:good_weather_create) { SplitUpsert.new(app: default_app, name: "weather", weighting_registry: good_weather) }
 
   it 'creates a new split config for a new name' do
     expect(Split.find_by(name: "amazing")).to be_falsey
-    SplitCreation.create(app: default_app, name: "amazing", weighting_registry: { awesome: 100 })
+    SplitUpsert.create(app: default_app, name: "amazing", weighting_registry: { awesome: 100 })
     expect(Split.find_by(name: "amazing", feature_gate: false)).to be_truthy
   end
 
   it 'creates feature gates when name ends in _enabled' do
     expect(Split.find_by(name: "foo_enabled")).to be_falsey
-    SplitCreation.create(app: default_app, name: "foo_enabled", weighting_registry: { awesome: 100 })
+    SplitUpsert.create(app: default_app, name: "foo_enabled", weighting_registry: { awesome: 100 })
     expect(Split.find_by(name: "foo_enabled", feature_gate: true)).to be_truthy
   end
 
@@ -55,10 +55,10 @@ RSpec.describe SplitCreation do
   end
 
   it 'delegates validation errors to split' do
-    split_creation = SplitCreation.new(app: default_app, name: "bad_test", weighting_registry: { badBadBad: 100 })
-    expect(split_creation.save).to eq false
-    expect(split_creation.errors[:name].first).to include("redundant")
-    expect(split_creation.errors[:weighting_registry].first).to include("snake_case")
+    split_upsert = SplitUpsert.new(app: default_app, name: "bad_test", weighting_registry: { badBadBad: 100 })
+    expect(split_upsert.save).to eq false
+    expect(split_upsert.errors[:name].first).to include("redundant")
+    expect(split_upsert.errors[:weighting_registry].first).to include("snake_case")
   end
 
   context 'when updating existing split' do


### PR DESCRIPTION
### Summary

@smudge this is in response to some of your feedback on #98. I also took this opportunity to ratchet down the set of parameters that build_config has control over - it wasn't really sensible for it to work the way it did, and wasn't exercised that way in live code, so I fixed the tests.

/domain @smudge
/platform @smudge
/cc @samandmoore